### PR TITLE
ci: use cibuildwheel action and build arm wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -13,22 +13,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v5
+      - name: Set up QEMU
+        if: ${{ (runner.os == 'Linux') }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.18.1
-
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir dist
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
+      - name: Build wheels for ${{ matrix.os }}
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          # On an Linux Intel runner with qemu installed, build Intel and ARM wheels
+          CIBW_ARCHS_LINUX: "auto aarch64"
 
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./dist/*.whl
+          path: ./wheelhouse/*.whl
 
   make_sdist:
     name: Make SDist

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,6 +33,11 @@ jobs:
           echo "CIBW_ARCHS_LINUX=aarch64" >> $GITHUB_ENV
           echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
 
+      - name: Skip some python flavors on slow emulated linux builds
+        if: ${{ (runner.os == 'Linux') && (matrix.arch == 'arm64') }}
+        run: |
+          echo "CIBW_SKIP=*musllinux* pp* cp36-* cp37-* cp38-*" >> $GITHUB_ENV
+
       - name: Build wheels for ${{ matrix.os }}-${{ matrix.arch }}
         uses: pypa/cibuildwheel@v2.22.0
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -9,25 +9,34 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        arch: [ 'x86_64', 'aarch64' ]
+        exclude:
+          - os: windows-latest
+            arch: aarch64
+          - os: macos-13
+            arch: aarch64
+          - os: macos-14
+            arch: aarch64
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: ${{ (runner.os == 'Linux') }}
+        if: ${{ (runner.os == 'Linux') && (matrix.arch == 'aarch64') }}
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
-      - name: Build wheels for ${{ matrix.os }}
+      - name: Set env for ${{ matrix.arch }}
+        run: |
+          echo "CIBW_ARCHS_LINUX=${{ matrix.arch }}" >> $GITHUB_ENV
+
+      - name: Build wheels for ${{ matrix.os }}-${{ matrix.arch }}
         uses: pypa/cibuildwheel@v2.22.0
-        env:
-          # On an Linux Intel runner with qemu installed, build Intel and ARM wheels
-          CIBW_ARCHS_LINUX: "auto aarch64"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   make_sdist:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, release]
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -9,27 +9,29 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-        arch: [ 'x86_64', 'aarch64' ]
+        arch: [ 'x86_64', 'arm64' ]
         exclude:
           - os: windows-latest
-            arch: aarch64
+            arch: arm64
           - os: macos-13
-            arch: aarch64
+            arch: arm64
           - os: macos-14
-            arch: aarch64
+            arch: x86_64
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: ${{ (runner.os == 'Linux') && (matrix.arch == 'aarch64') }}
+        if: ${{ (runner.os == 'Linux') && (matrix.arch == 'arm64') }}
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
-      - name: Set env for ${{ matrix.arch }}
+      - name: Sets env for arm64
+        if: matrix.arch == 'arm64'
         run: |
-          echo "CIBW_ARCHS_LINUX=${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "CIBW_ARCHS_LINUX=aarch64" >> $GITHUB_ENV
+          echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
 
       - name: Build wheels for ${{ matrix.os }}-${{ matrix.arch }}
         uses: pypa/cibuildwheel@v2.22.0


### PR DESCRIPTION
This change switches to the cibuildwheel action, simplifying the flow. Piggy-backed build packages for linux on arm.